### PR TITLE
EE-2516 Patch vulnerabilities in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM nginx
+FROM harbor.ci.nutmeg.co.uk/dockerhub/library/nginx:1.21-alpine
+
+# Patch vulnerabilities
+RUN apk add --upgrade --no-cache \
+      curl \
+      libxml2
 
 ADD default.conf /etc/nginx/conf.d/default.conf
 ADD css/ /opt/www/file-browser/css/


### PR DESCRIPTION
Patch vulnerabilities in OS by moving from Debian to Alpine and patching the remaining vulnerabilities.